### PR TITLE
Make npm commands like `npm run lint` work. Add `npm run build`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
-    "test": "grunt test",
-    "lint": "grunt jshint"
+    "test": "gulp test",
+    "lint": "gulp lint",
+    "build": "gulp build"
   }
 }


### PR DESCRIPTION
Since I an npm-dude, I ran `npm test` first and didn't succeed, so I made it work.
Great work on hamjest!!! Like the explicitness of the tests it makes!
Keep it up