### PR TITLE
Allow pure values in `assertThat()`

### DIFF
--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -3,12 +3,18 @@
 const _ = require('lodash');
 const AssertionError = require('assertion-error');
 const Description = require('./Description');
+const {isMatcher} = require('./matchers/Matcher');
+const {equalTo} = require('./matchers/IsEqual');
 
 function assertThat(reason, actual, matcher) {
 	if (arguments.length === 2) {
 		matcher = actual;
 		actual = reason;
 		reason = '';
+	}
+
+	if (!isMatcher(matcher)) {
+		matcher = equalTo(matcher);
 	}
 
 	const matches = matcher.matches(actual);

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -16,7 +16,7 @@ const processArgs = (args) => {
 	return {reason, actual, matcher: toMatcher(maybeMatcher)};
 };
 
-function assertThat(...args) {
+const assertThat = (...args) => {
 	const {reason, matcher, actual} = processArgs(args);
 	const matches = matcher.matches(actual);
 
@@ -44,6 +44,6 @@ function assertThat(...args) {
 
 		throw new AssertionError(description.get(), errorProperties, assertThat);
 	}
-}
+};
 
 module.exports = assertThat;

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -6,17 +6,18 @@ const Description = require('./Description');
 const {isMatcher} = require('./matchers/Matcher');
 const {equalTo} = require('./matchers/IsEqual');
 
-function assertThat(reason, actual, matcher) {
-	if (arguments.length === 2) {
-		matcher = actual;
-		actual = reason;
-		reason = '';
-	}
+const toMatcher = (x) => {
+	return isMatcher(x) ? x : equalTo(x);
+};
 
-	if (!isMatcher(matcher)) {
-		matcher = equalTo(matcher);
-	}
+const processArgs = (args) => {
+	const hasThreeArgs = args.length === 3;
+	const [reason, actual, maybeMatcher] = hasThreeArgs ? args : ['', ...args];
+	return {reason, actual, matcher: toMatcher(maybeMatcher)};
+};
 
+function assertThat(...args) {
+	const {reason, matcher, actual} = processArgs(args);
 	const matches = matcher.matches(actual);
 
 	if (matches && _.isFunction(matches.then)) {

--- a/test/node/assertThatSpec.js
+++ b/test/node/assertThatSpec.js
@@ -26,6 +26,11 @@ describe('assertThat', () => {
 		assert.ok(passedValue === input, 'Received: ' + passedValue);
 	});
 
+	it('should wrap non-matcher values in `equalTo()`', () => {
+		const fn = () => __.assertThat(true, true);
+		assert.doesNotThrow(fn);
+	});
+
 	it('should format assertion message if matcher fails', () => {
 		let thrown;
 


### PR DESCRIPTION
This makes `assertThat(true, true)` work too. Which used to fail before, because it expected `assertThat(true, equalTo(true))` which is done under the hood now.