### PR TITLE
unify naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Not impressed? I'll give it another try, using the builtin `FeatureMatcher`:
 
 ```JavaScript
 // Define a custom matcher using FeatureMatcher:
-function animalWithName(matcherOrValue) {
-	return new __.FeatureMatcher(matcherOrValue, 'animal with name', 'name');
+function animalWithName(valueOrMatcher) {
+	return new __.FeatureMatcher(valueOrMatcher, 'animal with name', 'name');
 }
 
 var animal = {name: 'Bob', age: 12};
@@ -96,8 +96,8 @@ Expected: is animal with name "Tom"
 By default, FeatureMatcher tries to find a property with the given feature name (the third parameter), but you can pass in an optional feature function:
 
 ```JavaScript
-function animalWithNameLength(matcherOrValue) {
-	return new __.FeatureMatcher(matcherOrValue, 'animal with name length', 'name length', function (item) {
+function animalWithNameLength(valueOrMatcher) {
+	return new __.FeatureMatcher(valueOrMatcher, 'animal with name length', 'name length', function (item) {
 		return item.name.length;
 	});
 }

--- a/dist/hamjest.js
+++ b/dist/hamjest.js
@@ -515,8 +515,8 @@ var Every = acceptingMatcher(function (matcher) {
 	});
 });
 
-Every.everyItem = function (matcherOrValue) {
-	return new Every(matcherOrValue);
+Every.everyItem = function (valueOrMatcher) {
+	return new Every(valueOrMatcher);
 };
 
 module.exports = Every;
@@ -863,8 +863,8 @@ var IsArrayWithItem = acceptingMatcher(function (matcher) {
 	});
 });
 
-IsArrayWithItem.hasItem = function (matcherOrValue) {
-	return new IsArrayWithItem(matcherOrValue);
+IsArrayWithItem.hasItem = function (valueOrMatcher) {
+	return new IsArrayWithItem(valueOrMatcher);
 };
 
 module.exports = IsArrayWithItem;
@@ -1562,8 +1562,8 @@ function Matcher() {
 	});
 }
 
-Matcher.isMatcher = function (matcherOrValue) {
-	return !_.isUndefined(matcherOrValue) && !_.isNull(matcherOrValue) && _.isFunction(matcherOrValue.matches) && _.isFunction(matcherOrValue.describeTo) && _.isFunction(matcherOrValue.describeMismatch);
+Matcher.isMatcher = function (valueOrMatcher) {
+	return !_.isUndefined(valueOrMatcher) && !_.isNull(valueOrMatcher) && _.isFunction(valueOrMatcher.matches) && _.isFunction(valueOrMatcher.describeTo) && _.isFunction(valueOrMatcher.describeMismatch);
 };
 
 module.exports = Matcher;
@@ -1906,8 +1906,8 @@ var _ = require('lodash');
 var TypeSafeMatcher = require('./TypeSafeMatcher');
 var FeatureMatcher = require('./FeatureMatcher');
 
-module.exports = function (matcherOrValue) {
-	var innerMatcher = new FeatureMatcher(matcherOrValue, 'a collection or string with size', 'size', function (item) {
+module.exports = function (valueOrMatcher) {
+	var innerMatcher = new FeatureMatcher(valueOrMatcher, 'a collection or string with size', 'size', function (item) {
 		return _.size(item);
 	});
 	return _.create(new TypeSafeMatcher(), {
@@ -2067,8 +2067,8 @@ var asMatcher = require('../utils/asMatcher');
 var func = require('./IsFunction').func;
 var getType = require('../utils/getType');
 
-module.exports = function returns(resultMatcherOrValue) {
-	var resultMatcher = resultMatcherOrValue ? asMatcher(resultMatcherOrValue) : anything();
+module.exports = function returns(resultValueOrMatcher) {
+	var resultMatcher = resultValueOrMatcher? asMatcher(resultValueOrMatcher) : anything();
 	return _.create(func(), {
 		matchesSafely: function matchesSafely(actual) {
 			try {
@@ -2122,8 +2122,8 @@ var asMatcher = require('../utils/asMatcher');
 var getType = require('../utils/getType');
 var getTypeName = require('../utils/getTypeName');
 
-module.exports = function typedError(errorType, messageMatcherOrValue) {
-	var messageMatcher = asMatcher(messageMatcherOrValue);
+module.exports = function typedError(errorType, messageValueOrMatcher) {
+	var messageMatcher = asMatcher(messageValueOrMatcher);
 	return {
 		matches: function matches(actual) {
 			return actual instanceof errorType && messageMatcher.matches(actual.message);

--- a/lib/matchers/Every.js
+++ b/lib/matchers/Every.js
@@ -47,8 +47,8 @@ const Every = acceptingMatcher((matcher) => {
 	});
 });
 
-Every.everyItem = function (matcherOrValue) {
-	return new Every(matcherOrValue);
+Every.everyItem = function (valueOrMatcher) {
+	return new Every(valueOrMatcher);
 };
 
 module.exports = Every;

--- a/lib/matchers/IsArrayWithItem.js
+++ b/lib/matchers/IsArrayWithItem.js
@@ -40,8 +40,8 @@ const IsArrayWithItem = acceptingMatcher((matcher) => {
 	});
 });
 
-IsArrayWithItem.hasItem = function (matcherOrValue) {
-	return new IsArrayWithItem(matcherOrValue);
+IsArrayWithItem.hasItem = function (valueOrMatcher) {
+	return new IsArrayWithItem(valueOrMatcher);
 };
 
 module.exports = IsArrayWithItem;

--- a/lib/matchers/Matcher.js
+++ b/lib/matchers/Matcher.js
@@ -16,12 +16,12 @@ function Matcher() {
 	});
 }
 
-Matcher.isMatcher = function (matcherOrValue) {
-	return !_.isUndefined(matcherOrValue) &&
-		!_.isNull(matcherOrValue) &&
-		_.isFunction(matcherOrValue.matches) &&
-		_.isFunction(matcherOrValue.describeTo) &&
-		_.isFunction(matcherOrValue.describeMismatch);
+Matcher.isMatcher = function (valueOrMatcher) {
+	return !_.isUndefined(valueOrMatcher) &&
+		!_.isNull(valueOrMatcher) &&
+		_.isFunction(valueOrMatcher.matches) &&
+		_.isFunction(valueOrMatcher.describeTo) &&
+		_.isFunction(valueOrMatcher.describeMismatch);
 };
 
 module.exports = Matcher;

--- a/lib/matchers/hasSize.js
+++ b/lib/matchers/hasSize.js
@@ -4,8 +4,8 @@ const _ = require('lodash');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 const FeatureMatcher = require('./FeatureMatcher');
 
-module.exports = function (matcherOrValue) {
-	const innerMatcher = new FeatureMatcher(matcherOrValue, 'a collection or string with size', 'size', (item) => _.size(item));
+module.exports = function (valueOrMatcher) {
+	const innerMatcher = new FeatureMatcher(valueOrMatcher, 'a collection or string with size', 'size', (item) => _.size(item));
 	return _.create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
 			return _.isString(actual) || _.isObject(actual);

--- a/lib/matchers/returns.js
+++ b/lib/matchers/returns.js
@@ -6,8 +6,8 @@ const asMatcher = require('../utils/asMatcher');
 const func = require('./IsFunction').func;
 const getType = require('../utils/getType');
 
-module.exports = function returns(resultMatcherOrValue) {
-	const resultMatcher = resultMatcherOrValue ? asMatcher(resultMatcherOrValue) : anything();
+module.exports = function returns(resultValueOrMatcher) {
+	const resultMatcher = resultValueOrMatcher ? asMatcher(resultValueOrMatcher) : anything();
 	return _.create(func(), {
 		matchesSafely: function (actual) {
 			try {

--- a/lib/matchers/typedError.js
+++ b/lib/matchers/typedError.js
@@ -4,8 +4,8 @@ const asMatcher = require('../utils/asMatcher');
 const getType = require('../utils/getType');
 const getTypeName = require('../utils/getTypeName');
 
-module.exports = function typedError(errorType, messageMatcherOrValue) {
-	const messageMatcher = asMatcher(messageMatcherOrValue);
+module.exports = function typedError(errorType, messageValueOrMatcher) {
+	const messageMatcher = asMatcher(messageValueOrMatcher);
 	return {
 		matches: function (actual) {
 			return actual instanceof errorType &&

--- a/test/node/DescriptionSpec.js
+++ b/test/node/DescriptionSpec.js
@@ -93,7 +93,7 @@ describe('Description', () => {
 		assert.equal(sut.get(), '[<5>, a matcher description, "foo"]');
 	});
 
-	describe('appendDescriptionOf(matcherOrValue)', () => {
+	describe('appendDescriptionOf(valueOrMatcher)', () => {
 		it('should append matcher description', () => {
 			const matcher = _.create(new __.Matcher(), {
 				describeTo: function (description) {

--- a/test/node/failSpec.js
+++ b/test/node/failSpec.js
@@ -5,10 +5,10 @@ const __ = require('../..');
 
 describe('fail', () => {
 	it('with a reason: should throw an AssertionError with the reason', () => {
-		function assertionErrorWithMessage(matcherOrValue) {
+		function assertionErrorWithMessage(valueOrMatcher) {
 			return __.allOf(
 				__.instanceOf(AssertionError),
-				new __.FeatureMatcher(matcherOrValue, 'AssertionError with message', 'message')
+				new __.FeatureMatcher(valueOrMatcher, 'AssertionError with message', 'message')
 			);
 		}
 

--- a/test/node/matchers/FeatureMatcherSpec.js
+++ b/test/node/matchers/FeatureMatcherSpec.js
@@ -7,8 +7,8 @@ const Animal = require('../zoo').Animal;
 describe('FeatureMatcher', () => {
 
 	describe('without feature function', () => {
-		function creatureWithName(matcherOrValue) {
-			return new __.FeatureMatcher(matcherOrValue, 'creature with name', 'name');
+		function creatureWithName(valueOrMatcher) {
+			return new __.FeatureMatcher(valueOrMatcher, 'creature with name', 'name');
 		}
 
 		it('should use feature name as property name', () => {
@@ -57,8 +57,8 @@ describe('FeatureMatcher', () => {
 	});
 
 	describe('with feature function', () => {
-		function creatureWithNameLength(matcherOrValue) {
-			return new __.FeatureMatcher(matcherOrValue, 'creature with name length', 'name length', (actual) => _.size(actual.name));
+		function creatureWithNameLength(valueOrMatcher) {
+			return new __.FeatureMatcher(valueOrMatcher, 'creature with name length', 'name length', (actual) => _.size(actual.name));
 		}
 		let sut;
 		beforeEach(() => {

--- a/test/node/matchers/IsFunctionThrowingSpec.js
+++ b/test/node/matchers/IsFunctionThrowingSpec.js
@@ -119,10 +119,10 @@ describe('IsFunctionThrowing', () => {
 				};
 			}
 
-			function assertionErrorWithMessage(matcherOrValue) {
+			function assertionErrorWithMessage(valueOrMatcher) {
 				return __.allOf(
 					__.instanceOf(AssertionError),
-					new __.FeatureMatcher(matcherOrValue, 'AssertionError with message', 'message')
+					new __.FeatureMatcher(valueOrMatcher, 'AssertionError with message', 'message')
 				);
 			}
 

--- a/test/node/matchers/hasDescriptionSpec.js
+++ b/test/node/matchers/hasDescriptionSpec.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const __ = require('../../..');
 
-describe('hasDescription(matcherOrValue)', () => {
+describe('hasDescription(valueOrMatcher)', () => {
 	_.forEach([
 		[__.hasSize(3), __.containsString('WILL NEVER MATCH'), false],
 		[__.hasSize(3), __.containsString('size <3>'), true],


### PR DESCRIPTION
always use "valueOrMatcher" instead of "matcherOrValue"