### PR TITLE
fix: `parameter has name but no type error`

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -2,7 +2,7 @@ declare module 'hamjest' {
 	type Value = any;
 
 	export class Matcher {
-		constructor(fns?: {matches?: (Value) => boolean; describeTo?: (Description) => void; describeMismatch?: (Value, Description) => void});
+		constructor(fns?: {matches?: (value: Value) => boolean; describeTo?: (description: Description) => void; describeMismatch?: (value: Value, description: Description) => void});
 		matches(actual: Value): boolean;
 		describeTo(description: Description): void;
 		describeMismatch(value: Value, description: Description): void;
@@ -11,7 +11,7 @@ declare module 'hamjest' {
 	type ValueOrMatcher = Value | Matcher;
 
 	export class TypeSafeMatcher<T> extends Matcher {
-		constructor(fns?: {isExpectedType?: (Value) => boolean; matchesSafely?: (T) => boolean; describeTo?: (Description) => void; describeMismatchSafely?: (T, Description) => void});
+		constructor(fns?: {isExpectedType?: (value: Value) => boolean; matchesSafely?: (actual: T) => boolean; describeTo?: (description: Description) => void; describeMismatchSafely?: (value: T, description: Description) => void});
 		isExpectedType(actual: Value): boolean;
 		matchesSafely(actual: T): boolean;
 		describeMismatchSafely(value: T, description: Description): void;


### PR DESCRIPTION
When using strict mode in one of my projects I get the following error when running `tsc`.

`Parameter has a name but no type. Did you mean 'arg0: Value'?`

This MR adds the missing types to the parameters.