### PR TITLE
`assertThat()` also allows pure value (instead of matcher) - reflect that in the types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -33,8 +33,8 @@ declare module 'hamjest' {
 		get(): string;
 	}
 
-	export function assertThat(actual: Value, matcher: Matcher): void;
-	export function assertThat(reason: string, actual: Value, matcher: Matcher): void;
+	export function assertThat(actual: Value, matcher: ValueOrMatcher): void;
+	export function assertThat(reason: string, actual: Value, matcher: ValueOrMatcher): void;
 
 	export function promiseThat(actual: Promise<Value>, matcher: Matcher): Promise<any>;
 	export function promiseThat(reason: string, actual: Promise<Value>, matcher: Matcher): Promise<any>;

--- a/@types/typeTests.ts
+++ b/@types/typeTests.ts
@@ -8,6 +8,8 @@ __.assertThat(2, __.not(__.equalTo(1)));
 __.assertThat(2, __.is(__.not(1)));
 __.assertThat(2, __.is(__.not(__.equalTo(1))));
 __.assertThat(2, __.is(__.not(__.equalTo(1))));
+__.assertThat({one: 1}, {one: 1});
+__.assertThat('a reason', {one: 1}, {one: 1});
 
 // Primitives
 __.assertThat(true, __.truthy());


### PR DESCRIPTION
Until now `assertThat({one: 1}, {one: 1})` was not reflected in the @types, but it is valid for how to use hamjest. This PR fixes this.