### PR TITLE
Make ESM named imports work

### DIFF
--- a/lib/hamjest.js
+++ b/lib/hamjest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const IsEqual = require('./matchers/IsEqual');
 const Matcher = require('./matchers/Matcher');
 const SubstringMatcher = require('./matchers/SubstringMatcher');
@@ -10,97 +9,89 @@ const Description = require('./Description');
 
 require('./fixErrorJson')();
 
-const asserts = {
-	assertThat: require('./assertThat'),
-	promiseThat: require('./promiseThat'),
-	fail: require('./fail')
+// asserts
+module.exports.assertThat = require('./assertThat');
+module.exports.promiseThat = require('./promiseThat');
+module.exports.fail = require('./fail');
+
+// matchers
+module.exports.Matcher = Matcher;
+module.exports.TypeSafeMatcher = require('./matchers/TypeSafeMatcher');
+module.exports.FeatureMatcher = require('./matchers/FeatureMatcher');
+
+module.exports.anything = require('./matchers/IsAnything').anything;
+module.exports.strictlyEqualTo = require('./matchers/IsSame').strictlyEqualTo;
+module.exports.is = require('./matchers/Is').is;
+module.exports.not = require('./matchers/IsNot').not;
+module.exports.equalTo = IsEqual.equalTo;
+module.exports.truthy = require('./matchers/truthy');
+module.exports.falsy = require('./matchers/falsy');
+module.exports.falsey = require('./matchers/falsy');
+module.exports.defined = require('./matchers/IsDefined').defined;
+module.exports.undefined = require('./matchers/IsDefined').undefined;
+module.exports.undef = require('./matchers/IsDefined').undefined;
+module.exports.instanceOf = require('./matchers/IsInstanceOf').instanceOf;
+module.exports.array = require('./matchers/IsArray').array;
+module.exports.bool = require('./matchers/IsBoolean').bool;
+module.exports.boolean = require('./matchers/IsBoolean').bool;
+module.exports.date = require('./matchers/IsDate').date;
+module.exports.func = require('./matchers/IsFunction').func;
+module.exports.number = require('./matchers/IsNumber').number;
+module.exports.object = require('./matchers/IsObject').object;
+module.exports.regExp = require('./matchers/IsRegExp').regExp;
+module.exports.string = require('./matchers/IsString').string;
+module.exports.containsString = SubstringMatcher.containsString;
+module.exports.containsStrings = SubstringMatcher.containsStrings;
+module.exports.startsWith = SubstringMatcher.startsWith;
+module.exports.endsWith = SubstringMatcher.endsWith;
+module.exports.matchesPattern = require('./matchers/IsStringMatching').matchesPattern;
+module.exports.matches = require('./matchers/matches');
+module.exports.failsToMatch = require('./matchers/failsToMatch');
+module.exports.hasDescription = require('./matchers/hasDescription');
+module.exports.lessThan = NumberComparisonMatcher.lessThan;
+module.exports.lessThanOrEqualTo = NumberComparisonMatcher.lessThanOrEqualTo;
+module.exports.greaterThan = NumberComparisonMatcher.greaterThan;
+module.exports.greaterThanOrEqualTo = NumberComparisonMatcher.greaterThanOrEqualTo;
+module.exports.inRange = require('./matchers/inRange');
+module.exports.after = DateComparisonMatcher.after;
+module.exports.afterOrEqualTo = DateComparisonMatcher.afterOrEqualTo;
+module.exports.before = DateComparisonMatcher.before;
+module.exports.beforeOrEqualTo = DateComparisonMatcher.beforeOrEqualTo;
+module.exports.closeTo = require('./matchers/IsCloseTo').closeTo;
+module.exports.allOf = require('./matchers/AllOf').allOf;
+module.exports.anyOf = require('./matchers/AnyOf').anyOf;
+module.exports.everyItem = require('./matchers/Every').everyItem;
+module.exports.hasItem = require('./matchers/IsArrayWithItem').hasItem;
+module.exports.hasItems = require('./matchers/IsArrayWithItems').hasItems;
+module.exports.hasExactlyOneItem = require('./matchers/hasExactlyOneItem');
+module.exports.contains = require('./matchers/IsArrayContaining').contains;
+module.exports.containsInAnyOrder = require('./matchers/IsArrayContainingInAnyOrder').containsInAnyOrder;
+module.exports.orderedBy = require('./matchers/IsArrayOrderedBy').orderedBy;
+module.exports.hasSize = require('./matchers/hasSize');
+module.exports.isEmpty = require('./matchers/isEmpty');
+module.exports.empty = require('./matchers/isEmpty');
+module.exports.hasProperties = require('./matchers/IsObjectWithProperties').hasProperties;
+module.exports.hasDeepProperties = require('./matchers/IsObjectWithProperties').hasDeepProperties;
+module.exports.hasProperty = require('./matchers/IsObjectWithProperties').hasProperty;
+module.exports.throws = require('./matchers/IsFunctionThrowing').throws;
+module.exports.returns = require('./matchers/returns');
+module.exports.typedError = require('./matchers/typedError');
+module.exports.promise = require('./matchers/IsPromise').promise;
+module.exports.fulfilled = require('./matchers/IsFulfilled').fulfilled;
+module.exports.isFulfilledWith = require('./matchers/IsFulfilled').isFulfilledWith;
+module.exports.willBe = require('./matchers/IsFulfilled').isFulfilledWith;
+module.exports.rejected = require('./matchers/IsRejected').rejected;
+module.exports.isRejectedWith = require('./matchers/IsRejected').isRejectedWith;
+// Deprecated
+module.exports.promiseAllOf = require('./matchers/AllOf').allOf;
+
+// utils
+module.exports.isMatcher = Matcher.isMatcher;
+module.exports.asMatcher = require('./utils/asMatcher');
+module.exports.acceptingMatcher = require('./utils/acceptingMatcher');
+module.exports.Description = Description;
+module.exports.describe = function (matcher) {
+	return new Description()
+		.appendDescriptionOf(matcher)
+		.get();
 };
-
-const matchers = {
-	Matcher: Matcher,
-	TypeSafeMatcher: require('./matchers/TypeSafeMatcher'),
-	FeatureMatcher: require('./matchers/FeatureMatcher'),
-
-	anything: require('./matchers/IsAnything').anything,
-	strictlyEqualTo: require('./matchers/IsSame').strictlyEqualTo,
-	is: require('./matchers/Is').is,
-	not: require('./matchers/IsNot').not,
-	equalTo: IsEqual.equalTo,
-	truthy: require('./matchers/truthy'),
-	falsy: require('./matchers/falsy'),
-	falsey: require('./matchers/falsy'),
-	defined: require('./matchers/IsDefined').defined,
-	undefined: require('./matchers/IsDefined').undefined,
-	undef: require('./matchers/IsDefined').undefined,
-	instanceOf: require('./matchers/IsInstanceOf').instanceOf,
-	array: require('./matchers/IsArray').array,
-	bool: require('./matchers/IsBoolean').bool,
-	boolean: require('./matchers/IsBoolean').bool,
-	date: require('./matchers/IsDate').date,
-	func: require('./matchers/IsFunction').func,
-	number: require('./matchers/IsNumber').number,
-	object: require('./matchers/IsObject').object,
-	regExp: require('./matchers/IsRegExp').regExp,
-	string: require('./matchers/IsString').string,
-	containsString: SubstringMatcher.containsString,
-	containsStrings: SubstringMatcher.containsStrings,
-	startsWith: SubstringMatcher.startsWith,
-	endsWith: SubstringMatcher.endsWith,
-	matchesPattern: require('./matchers/IsStringMatching').matchesPattern,
-	matches: require('./matchers/matches'),
-	failsToMatch: require('./matchers/failsToMatch'),
-	hasDescription: require('./matchers/hasDescription'),
-	lessThan: NumberComparisonMatcher.lessThan,
-	lessThanOrEqualTo: NumberComparisonMatcher.lessThanOrEqualTo,
-	greaterThan: NumberComparisonMatcher.greaterThan,
-	greaterThanOrEqualTo: NumberComparisonMatcher.greaterThanOrEqualTo,
-	inRange: require('./matchers/inRange'),
-	after: DateComparisonMatcher.after,
-	afterOrEqualTo: DateComparisonMatcher.afterOrEqualTo,
-	before: DateComparisonMatcher.before,
-	beforeOrEqualTo: DateComparisonMatcher.beforeOrEqualTo,
-	closeTo: require('./matchers/IsCloseTo').closeTo,
-	allOf: require('./matchers/AllOf').allOf,
-	anyOf: require('./matchers/AnyOf').anyOf,
-	everyItem: require('./matchers/Every').everyItem,
-	hasItem: require('./matchers/IsArrayWithItem').hasItem,
-	hasItems: require('./matchers/IsArrayWithItems').hasItems,
-	hasExactlyOneItem: require('./matchers/hasExactlyOneItem'),
-	contains: require('./matchers/IsArrayContaining').contains,
-	containsInAnyOrder: require('./matchers/IsArrayContainingInAnyOrder').containsInAnyOrder,
-	orderedBy: require('./matchers/IsArrayOrderedBy').orderedBy,
-	hasSize: require('./matchers/hasSize'),
-	isEmpty: require('./matchers/isEmpty'),
-	empty: require('./matchers/isEmpty'),
-	hasProperties: require('./matchers/IsObjectWithProperties').hasProperties,
-	hasDeepProperties: require('./matchers/IsObjectWithProperties').hasDeepProperties,
-	hasProperty: require('./matchers/IsObjectWithProperties').hasProperty,
-	throws: require('./matchers/IsFunctionThrowing').throws,
-	returns: require('./matchers/returns'),
-	typedError: require('./matchers/typedError'),
-	promise: require('./matchers/IsPromise').promise,
-	fulfilled: require('./matchers/IsFulfilled').fulfilled,
-	isFulfilledWith: require('./matchers/IsFulfilled').isFulfilledWith,
-	willBe: require('./matchers/IsFulfilled').isFulfilledWith,
-	rejected: require('./matchers/IsRejected').rejected,
-	isRejectedWith: require('./matchers/IsRejected').isRejectedWith,
-	// Deprecated
-	promiseAllOf: require('./matchers/AllOf').allOf
-};
-
-const utils = {
-	isMatcher: Matcher.isMatcher,
-	asMatcher: require('./utils/asMatcher'),
-	acceptingMatcher: require('./utils/acceptingMatcher'),
-	Description: Description,
-	describe: function (matcher) {
-		return new Description()
-			.appendDescriptionOf(matcher)
-			.get();
-	}
-};
-
-const hamjest = {};
-_.extend(hamjest, asserts, matchers, utils);
-
-module.exports = hamjest;

--- a/test/node/esm/package.json
+++ b/test/node/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/node/esm/providesNamedImports.js
+++ b/test/node/esm/providesNamedImports.js
@@ -1,0 +1,3 @@
+import { assertThat, equalTo } from '../../../index.js';
+
+assertThat('If this test fails, ESM named-imports (might) fail.', 0, equalTo(0));


### PR DESCRIPTION
Make named imports in type=module packages work.

## Summary
This MR makes `import {whatever} from 'hamjest'` work, by exporting each 
function explicitly so its easy to statically analyze the file, which makes it work.
Explicit exporting is done by exporting each function directly via `module.exports.assertThat = ...`.

## Details    
In [this article][1] I learned how nodejs "interprets" and "understands"
commonjs files, which mainly happens in the file `lib/hamjest.js`. In order for
named imports like `import {assertThat} from 'hamjest'` to work, the export
must be simpler (simply said). That is what this MR does, it allows
to statically analyse the hamjest package and make it work when imported
as ESM.
    
I dont know how to include the test in the gulp file, I have no idea how to
run a simple nodejs file within gulp.
    
Also, this requires a recent nodejs version, with v14 I didn't get the test to
pass, v16 this test passes. Even though the change should work on any relevant node version.


[1]: https://simonplend.com/node-js-now-supports-named-imports-from-commonjs-modules-but-what-does-that-mean/
