### PR TITLE
chore: reduce package size

### DIFF
--- a/lib/Description.js
+++ b/lib/Description.js
@@ -1,10 +1,18 @@
 'use strict';
 
-const _ = require('lodash');
+const _forEach = require('lodash/forEach');
+const _isArray = require('lodash/isArray');
+const _isFunction = require('lodash/isFunction');
+const _isNull = require('lodash/isNull');
+const _isNumber = require('lodash/isNumber');
+const _isRegExp = require('lodash/isRegExp');
+const _isString = require('lodash/isString');
+const _isUndefined = require('lodash/isUndefined');
+const _padEnd = require('lodash/padEnd');
 const Bluebird = require('bluebird');
 
 function asSelfDescribing(value) {
-	if (!value || !_.isFunction(value.describeTo)) {
+	if (!value || !_isFunction(value.describeTo)) {
 		return {
 			describeTo(description) {
 				description.appendValue(value);
@@ -26,7 +34,7 @@ function Description() {
 		indentation: 0,
 		append(text) {
 			if (this.indentation) {
-				text = ('' + text).replace('\n', _.padEnd('\n', this.indentation + 1, '\t'));
+				text = ('' + text).replace('\n', _padEnd('\n', this.indentation + 1, '\t'));
 			}
 			try {
 				value += text;
@@ -38,7 +46,7 @@ function Description() {
 		indented(describingfn) {
 			this.indentation += 1;
 			const result = describingfn();
-			if (result && _.isFunction(result.then)) {
+			if (result && _isFunction(result.then)) {
 				return Bluebird.resolve(result)
 				.finally(() => {
 					this.indentation -= 1;
@@ -49,7 +57,7 @@ function Description() {
 			}
 		},
 		appendDescriptionOf(selfDescribing) {
-			if (selfDescribing && _.isFunction(selfDescribing.describeTo)) {
+			if (selfDescribing && _isFunction(selfDescribing.describeTo)) {
 				selfDescribing.describeTo(this);
 			} else {
 				this.appendValue(selfDescribing);
@@ -57,19 +65,19 @@ function Description() {
 			return this;
 		},
 		appendValue(value, indentLists) {
-			if (_.isUndefined(value)) {
+			if (_isUndefined(value)) {
 				this.append('undefined');
-			} else if (_.isNull(value)) {
+			} else if (_isNull(value)) {
 				this.append('null');
-			} else if (_.isString(value)) {
+			} else if (_isString(value)) {
 				this.append('"');
 				this.append(value);
 				this.append('"');
-			} else if (_.isNumber(value)) {
+			} else if (_isNumber(value)) {
 				this.append('<');
 				this.append(value);
 				this.append('>');
-			} else if (_.isArray(value)) {
+			} else if (_isArray(value)) {
 				if (indentLists && value.length > 1) {
 					this.indented(() => this.appendList('[\n', ',\n', '', value))
 						.append('\n]');
@@ -78,10 +86,10 @@ function Description() {
 				}
 			} else if (isDomNode(value)) {
 				this.append('DOM node ')
-					.appendValue(_.isFunction(value.html) ? value.html() : value.outerHTML);
-			} else if (_.isFunction(value)) {
+					.appendValue(_isFunction(value.html) ? value.html() : value.outerHTML);
+			} else if (_isFunction(value)) {
 				this.append('Function' + (value.name  ? ' ' + value.name : ''));
-			} else if (_.isRegExp(value)) {
+			} else if (_isRegExp(value)) {
 				this.append(value.toString());
 			} else if (this.useJsonForObjects) {
 				try {
@@ -100,7 +108,7 @@ function Description() {
 		appendNonJson(value) {
 			this.append('{');
 			let first = true;
-			_.forEach(value, (innerValue, key) => {
+			_forEach(value, (innerValue, key) => {
 				if (!first) {
 					this.append(', ');
 				}
@@ -113,7 +121,7 @@ function Description() {
 		},
 		appendList(start, separator, end, list) {
 			this.append(start);
-			_.forEach(list, (value, index) => {
+			_forEach(list, (value, index) => {
 				if (index !== 0) {
 					this.append(separator);
 				}
@@ -131,8 +139,8 @@ function Description() {
 		if (!value) {
 			return false;
 		}
-		return _.isFunction(value.appendChild) && _.isFunction(value.isEqualNode) && !_.isUndefined(value.outerHTML) ||
-			_.isFunction(value.html) && _.isFunction(value.text);
+		return _isFunction(value.appendChild) && _isFunction(value.isEqualNode) && !_isUndefined(value.outerHTML) ||
+			_isFunction(value.html) && _isFunction(value.text);
 	}
 }
 

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _isFunction = require('lodash/isFunction');
 const AssertionError = require('assertion-error');
 const Description = require('./Description');
 const asMatcher = require('./utils/asMatcher');
@@ -15,7 +15,7 @@ const assertThat = (...args) => {
 	const {reason, matcher, actual} = processArgs(args);
 	const matches = matcher.matches(actual);
 
-	if (matches && _.isFunction(matches.then)) {
+	if (matches && _isFunction(matches.then)) {
 		throw new AssertionError('Matcher returned a promise instead of a boolean - use promiseThat for promising matchers!', {}, assertThat);
 	}
 
@@ -28,8 +28,8 @@ const assertThat = (...args) => {
 		matcher.describeMismatch(actual, description);
 
 		let errorProperties = {};
-		if (_.isFunction(matcher.getExpectedForDiff) &&
-			_.isFunction(matcher.formatActualForDiff)) {
+		if (_isFunction(matcher.getExpectedForDiff) &&
+			_isFunction(matcher.formatActualForDiff)) {
 			errorProperties = {
 				showDiff: true,
 				expected: matcher.getExpectedForDiff(),

--- a/lib/matchers/AllOf.js
+++ b/lib/matchers/AllOf.js
@@ -1,23 +1,26 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _every = require('lodash/every');
+const _map = require('lodash/map');
+const _mapValues = require('lodash/mapValues');
 const Matcher = require('./Matcher');
 const promiseAgnostic = require('./promiseAgnostic');
 
 function AllOf(matchers) {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actual) {
-			const results = _.map(matchers, (matcher) => {
+			const results = _map(matchers, (matcher) => {
 				return matcher.matches(actual);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, _.every);
+			return promiseAgnostic.matchesAggregate(results, _every);
 		},
 		describeTo: function (description) {
 			description.appendList('(', ' and ', ')', matchers);
 		},
 		describeMismatch: function (actual, description) {
-			const results = _.mapValues(matchers, (matcher) => {
+			const results = _mapValues(matchers, (matcher) => {
 				return matcher.matches(actual);
 			});
 			let first = true;

--- a/lib/matchers/AnyOf.js
+++ b/lib/matchers/AnyOf.js
@@ -1,18 +1,20 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _map = require('lodash/map');
+const _some = require('lodash/some');
 const Matcher = require('./Matcher');
 const promiseAgnostic = require('./promiseAgnostic');
 const asMatcher = require('../utils/asMatcher');
 
 function AnyOf(matchers) {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actual) {
-			const results = _.map(matchers, (matcher) => {
+			const results = _map(matchers, (matcher) => {
 				return asMatcher(matcher).matches(actual);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, _.some);
+			return promiseAgnostic.matchesAggregate(results, _some);
 		},
 		describeTo: function (description) {
 			description.appendList('(', ' or ', ')', matchers);

--- a/lib/matchers/AnyOf.js
+++ b/lib/matchers/AnyOf.js
@@ -2,16 +2,14 @@
 
 const _ = require('lodash');
 const Matcher = require('./Matcher');
-
 const promiseAgnostic = require('./promiseAgnostic');
+const asMatcher = require('../utils/asMatcher');
 
 function AnyOf(matchers) {
-	const __ = require('../..');
-
 	return _.create(new Matcher(), {
 		matches: function (actual) {
 			const results = _.map(matchers, (matcher) => {
-				return __.asMatcher(matcher).matches(actual);
+				return asMatcher(matcher).matches(actual);
 			});
 
 			return promiseAgnostic.matchesAggregate(results, _.some);

--- a/lib/matchers/DateComparisonMatcher.js
+++ b/lib/matchers/DateComparisonMatcher.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsDate = require('./IsDate');
 const assertThat = require('../assertThat');
 const is = require('./Is').is;
@@ -9,7 +9,7 @@ const date = require('./IsDate').date;
 function DateComparisonMatcher(threshold, relation, matchesNumber) {
 	assertThat(threshold, is(date()));
 
-	return _.create(new IsDate(), {
+	return _create(new IsDate(), {
 		matchesSafely: function (actual) {
 			return matchesNumber.call(this, actual);
 		},

--- a/lib/matchers/DateComparisonMatcher.js
+++ b/lib/matchers/DateComparisonMatcher.js
@@ -28,27 +28,28 @@ function DateComparisonMatcher(threshold, relation, matchesNumber) {
 	});
 }
 
-_.extend(DateComparisonMatcher, {
-	after: function (threshold) {
-		return new DateComparisonMatcher(threshold, 'after', (actual) => {
-			return actual > threshold;
-		});
-	},
-	afterOrEqualTo: function (threshold) {
-		return new DateComparisonMatcher(threshold, 'after or equal to', (actual) => {
-			return actual >= threshold;
-		});
-	},
-	before: function (threshold) {
-		return new DateComparisonMatcher(threshold, 'before', (actual) => {
-			return actual < threshold;
-		});
-	},
-	beforeOrEqualTo: function (threshold) {
-		return new DateComparisonMatcher(threshold, 'before or equal to', (actual) => {
-			return actual <= threshold;
-		});
-	}
-});
+DateComparisonMatcher.after = function (threshold) {
+	return new DateComparisonMatcher(threshold, 'after', (actual) => {
+		return actual > threshold;
+	});
+};
+
+DateComparisonMatcher.afterOrEqualTo = function (threshold) {
+	return new DateComparisonMatcher(threshold, 'after or equal to', (actual) => {
+		return actual >= threshold;
+	});
+};
+
+DateComparisonMatcher.before = function (threshold) {
+	return new DateComparisonMatcher(threshold, 'before', (actual) => {
+		return actual < threshold;
+	});
+};
+
+DateComparisonMatcher.beforeOrEqualTo = function (threshold) {
+	return new DateComparisonMatcher(threshold, 'before or equal to', (actual) => {
+		return actual <= threshold;
+	});
+};
 
 module.exports = DateComparisonMatcher;

--- a/lib/matchers/Every.js
+++ b/lib/matchers/Every.js
@@ -1,22 +1,27 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _every = require('lodash/every');
+const _isArray = require('lodash/isArray');
+const _isObject = require('lodash/isObject');
+const _map = require('lodash/map');
+const _mapValues = require('lodash/mapValues');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
 const asMatcher = require('../utils/asMatcher');
 
 function Every(valueOrMatcher) {
 	const matcher = asMatcher(valueOrMatcher);
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isArray(actual) || _.isObject(actual);
+			return _isArray(actual) || _isObject(actual);
 		},
 		matchesSafely: function (actual) {
-			const results = _.map(actual, (value) => {
+			const results = _map(actual, (value) => {
 				return matcher.matches(value);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, _.every);
+			return promiseAgnostic.matchesAggregate(results, _every);
 		},
 		describeTo: function (description) {
 			description
@@ -25,12 +30,12 @@ function Every(valueOrMatcher) {
 		},
 		describeMismatchSafely: function (actual, description) {
 			let results;
-			if (_.isArray(actual)) {
-				results  = _.map(actual, (value) => {
+			if (_isArray(actual)) {
+				results  = _map(actual, (value) => {
 					return matcher.matches(value);
 				});
 			} else {
-				results  = _.mapValues(actual, (value) => {
+				results  = _mapValues(actual, (value) => {
 					return matcher.matches(value);
 				});
 			}

--- a/lib/matchers/Every.js
+++ b/lib/matchers/Every.js
@@ -2,10 +2,11 @@
 
 const _ = require('lodash');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
-const acceptingMatcher = require('../utils/acceptingMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
+const asMatcher = require('../utils/asMatcher');
 
-const Every = acceptingMatcher((matcher) => {
+function Every(valueOrMatcher) {
+	const matcher = asMatcher(valueOrMatcher);
 	return _.create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
 			return _.isArray(actual) || _.isObject(actual);
@@ -44,7 +45,7 @@ const Every = acceptingMatcher((matcher) => {
 			});
 		}
 	});
-});
+}
 
 Every.everyItem = function (valueOrMatcher) {
 	return new Every(valueOrMatcher);

--- a/lib/matchers/FeatureMatcher.js
+++ b/lib/matchers/FeatureMatcher.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 const asMatcher = require('../utils/asMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
@@ -11,7 +11,7 @@ function FeatureMatcher(valueOrMatcher, featureDescription, featureName, feature
 		return item[featureName];
 	};
 
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actual) {
 			const featureValue = featureFunction(actual);
 			return matcher.matches(featureValue);

--- a/lib/matchers/Is.js
+++ b/lib/matchers/Is.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 const asMatcher = require('../utils/asMatcher');
 
 function Is(valueOrMatcher) {
 	const innerMatcher = asMatcher(valueOrMatcher);
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actualValue) {
 			return innerMatcher.matches(actualValue);
 		},

--- a/lib/matchers/Is.js
+++ b/lib/matchers/Is.js
@@ -2,9 +2,10 @@
 
 const _ = require('lodash');
 const Matcher = require('./Matcher');
-const acceptingMatcher = require('../utils/acceptingMatcher');
+const asMatcher = require('../utils/asMatcher');
 
-const Is = acceptingMatcher((innerMatcher) => {
+function Is(valueOrMatcher) {
+	const innerMatcher = asMatcher(valueOrMatcher);
 	return _.create(new Matcher(), {
 		matches: function (actualValue) {
 			return innerMatcher.matches(actualValue);
@@ -20,7 +21,7 @@ const Is = acceptingMatcher((innerMatcher) => {
 		getExpectedForDiff: innerMatcher.getExpectedForDiff,
 		formatActualForDiff: innerMatcher.formatActualForDiff
 	});
-});
+}
 
 Is.is = function (innerMatcher) {
 	return new Is(innerMatcher);

--- a/lib/matchers/IsAnything.js
+++ b/lib/matchers/IsAnything.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 
 function IsAnything() {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function () {
 			return true;
 		},

--- a/lib/matchers/IsArray.js
+++ b/lib/matchers/IsArray.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isArray = require('lodash/isArray');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsArray() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isArray(actual);
+			return _isArray(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsArrayContaining.js
+++ b/lib/matchers/IsArrayContaining.js
@@ -1,29 +1,31 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _every = require('lodash/every');
+const _map = require('lodash/map');
 const IsArray = require('./IsArray');
 const asMatcher = require('../utils/asMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
 
 function IsArrayContaining(itemsOrMatchers) {
-	const matchers = _.map(itemsOrMatchers, asMatcher);
-	return _.create(new IsArray(), {
+	const matchers = _map(itemsOrMatchers, asMatcher);
+	return _create(new IsArray(), {
 		matchesSafely: function (actual) {
 			if (actual.length !== matchers.length) {
 				return false;
 			}
 
-			const results = _.map(matchers, (matcher, index) => {
+			const results = _map(matchers, (matcher, index) => {
 				return matcher.matches(actual[index]);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, _.every);
+			return promiseAgnostic.matchesAggregate(results, _every);
 		},
 		describeTo: function (description) {
 			description.appendList('[', ', ', ']', matchers);
 		},
 		describeMismatchSafely: function (actual, description) {
-			const results = _.map(actual, (value, index) => {
+			const results = _map(actual, (value, index) => {
 				if (matchers.length > index) {
 					return matchers[index].matches(value);
 				}

--- a/lib/matchers/IsArrayContainingInAnyOrder.js
+++ b/lib/matchers/IsArrayContainingInAnyOrder.js
@@ -1,17 +1,20 @@
 'use strict';
 
-const _ = require('lodash');
+const _clone = require('lodash/clone');
+const _create = require('lodash/create');
+const _forEach = require('lodash/forEach');
+const _map = require('lodash/map');
 const IsArray = require('./IsArray');
 const asMatcher = require('../utils/asMatcher');
 
 // TODO: Make promise agnostic
 
 function ConsumingMatcher(matchers) {
-	return _.create({}, {
-		unmatchedMatchers: _.clone(matchers),
+	return _create({}, {
+		unmatchedMatchers: _clone(matchers),
 		matches: function (actual) {
 			let matched = false;
-			_.forEach(this.unmatchedMatchers, (matcher, index) => {
+			_forEach(this.unmatchedMatchers, (matcher, index) => {
 				if (matcher.matches(actual)) {
 					matched = true;
 					this.unmatchedMatchers.splice(index, 1);
@@ -24,14 +27,14 @@ function ConsumingMatcher(matchers) {
 }
 
 const IsArrayContainingInAnyOrder = function IsArrayContainingInAnyOrder(itemsOrMatchers) {
-	const matchers = _.map(itemsOrMatchers, asMatcher);
-	return _.create(new IsArray(), {
+	const matchers = _map(itemsOrMatchers, asMatcher);
+	return _create(new IsArray(), {
 		matchesSafely: function (actual) {
 			if (actual.length !== matchers.length) {
 				return false;
 			}
 			const matcher = new ConsumingMatcher(matchers);
-			_.forEach(actual, (item) => {
+			_forEach(actual, (item) => {
 				if (!matcher.matches(item)) {
 					return false;
 				}
@@ -46,7 +49,7 @@ const IsArrayContainingInAnyOrder = function IsArrayContainingInAnyOrder(itemsOr
 		describeMismatchSafely: function (actual, description) {
 			const matcher = new ConsumingMatcher(matchers);
 			const unmatchedItems = [];
-			_.forEach(actual, (item) => {
+			_forEach(actual, (item) => {
 				if (!matcher.matches(item)) {
 					unmatchedItems.push(item);
 				}

--- a/lib/matchers/IsArrayOrderedBy.js
+++ b/lib/matchers/IsArrayOrderedBy.js
@@ -1,14 +1,15 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _reduce = require('lodash/reduce');
 const IsArray = require('./IsArray');
 
 function IsArrayOrderedBy(comp, compDescription) {
 	compDescription = compDescription || comp.name;
-	return _.create(new IsArray(), {
+	return _create(new IsArray(), {
 		matchesSafely: function (actual) {
 			let correctOrder = true;
-			_.reduce(actual, (previous, element) => {
+			_reduce(actual, (previous, element) => {
 				if (!comp(previous, element)) {
 					correctOrder = false;
 				}
@@ -24,7 +25,7 @@ function IsArrayOrderedBy(comp, compDescription) {
 		describeMismatchSafely: function (actual, description) {
 			let correctOrder = true;
 			let firstMismatch;
-			_.reduce(actual, (previous, element, index) => {
+			_reduce(actual, (previous, element, index) => {
 				if (!comp(previous, element) && correctOrder) {
 					correctOrder = false;
 					firstMismatch = {

--- a/lib/matchers/IsArrayWithItem.js
+++ b/lib/matchers/IsArrayWithItem.js
@@ -2,10 +2,11 @@
 
 const _ = require('lodash');
 const IsArray = require('./IsArray');
-const acceptingMatcher = require('../utils/acceptingMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
+const asMatcher = require('../utils/asMatcher');
 
-const IsArrayWithItem = acceptingMatcher((matcher) => {
+function IsArrayWithItem(valueOrMatcher) {
+	const matcher = asMatcher(valueOrMatcher);
 	return _.create(new IsArray(), {
 		matchesSafely: function (actual) {
 			const results = _.map(actual, (value) => {
@@ -38,7 +39,7 @@ const IsArrayWithItem = acceptingMatcher((matcher) => {
 			});
 		}
 	});
-});
+}
 
 IsArrayWithItem.hasItem = function (valueOrMatcher) {
 	return new IsArrayWithItem(valueOrMatcher);

--- a/lib/matchers/IsArrayWithItem.js
+++ b/lib/matchers/IsArrayWithItem.js
@@ -1,19 +1,21 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _map = require('lodash/map');
+const _some = require('lodash/some');
 const IsArray = require('./IsArray');
 const promiseAgnostic = require('./promiseAgnostic');
 const asMatcher = require('../utils/asMatcher');
 
 function IsArrayWithItem(valueOrMatcher) {
 	const matcher = asMatcher(valueOrMatcher);
-	return _.create(new IsArray(), {
+	return _create(new IsArray(), {
 		matchesSafely: function (actual) {
-			const results = _.map(actual, (value) => {
+			const results = _map(actual, (value) => {
 				return matcher.matches(value);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, _.some);
+			return promiseAgnostic.matchesAggregate(results, _some);
 		},
 		describeTo: function (description) {
 			description
@@ -25,7 +27,7 @@ function IsArrayWithItem(valueOrMatcher) {
 				description.append('was empty');
 				return;
 			}
-			const results = _.map(actual, (value) => {
+			const results = _map(actual, (value) => {
 				return matcher.matches(value);
 			});
 

--- a/lib/matchers/IsArrayWithItems.js
+++ b/lib/matchers/IsArrayWithItems.js
@@ -1,14 +1,16 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _forEach = require('lodash/forEach');
+const _map = require('lodash/map');
 const IsArray = require('./IsArray');
 const hasItem = require('./IsArrayWithItem').hasItem;
 const AllOf = require('./AllOf');
 const asMatcher = require('../utils/asMatcher');
 
 const IsArrayWithItems = function IsArrayWithItems(items) {
-	const innerMatcher = new AllOf(_.map(items, hasItem));
-	return _.create(new IsArray(), {
+	const innerMatcher = new AllOf(_map(items, hasItem));
+	return _create(new IsArray(), {
 		matchesSafely: function (actual) {
 			return innerMatcher.matches(actual);
 		},
@@ -16,7 +18,7 @@ const IsArrayWithItems = function IsArrayWithItems(items) {
 			description
 				.append('an array containing ');
 			let first = true;
-			_.forEach(items, (item) => {
+			_forEach(items, (item) => {
 				if (!first) {
 					description.append(', ');
 				}

--- a/lib/matchers/IsBoolean.js
+++ b/lib/matchers/IsBoolean.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isBoolean = require('lodash/isBoolean');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsBoolean() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isBoolean(actual);
+			return _isBoolean(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsCloseTo.js
+++ b/lib/matchers/IsCloseTo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsNumber = require('./IsNumber');
 const assertThat = require('../assertThat');
 const is = require('./Is').is;
@@ -14,7 +14,7 @@ function IsCloseTo(threshold, delta) {
 		return Math.abs(actual - threshold);
 	}
 
-	return _.create(new IsNumber(), {
+	return _create(new IsNumber(), {
 		matchesSafely: function (actual) {
 			return getDelta(actual) <= delta;
 		},

--- a/lib/matchers/IsDate.js
+++ b/lib/matchers/IsDate.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isDate = require('lodash/isDate');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsDate() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isDate(actual);
+			return _isDate(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsDefined.js
+++ b/lib/matchers/IsDefined.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isUndefined = require('lodash/isUndefined');
 const Matcher = require('./Matcher');
 const not = require('./IsNot').not;
 
 function IsDefined() {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actual) {
-			return !_.isUndefined(actual);
+			return !_isUndefined(actual);
 		},
 		describeTo: function (description) {
 			description.append('defined');

--- a/lib/matchers/IsEqual.js
+++ b/lib/matchers/IsEqual.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isEqual = require('lodash/isEqual');
 const Matcher = require('./Matcher');
 
 function IsEqual(expectedValue) {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actualValue) {
-			return _.isEqual(expectedValue, actualValue);
+			return _isEqual(expectedValue, actualValue);
 		},
 		describeTo: function (description) {
 			description.appendValue(expectedValue);

--- a/lib/matchers/IsFulfilled.js
+++ b/lib/matchers/IsFulfilled.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsPromise = require('./IsPromise');
 const asMatcher = require('../utils/asMatcher');
 const anything = require('./IsAnything').anything;
@@ -8,7 +8,7 @@ const anything = require('./IsAnything').anything;
 function IsFulfilled(valueOrMatcher) {
 	const anyValue = (arguments.length === 0);
 	const valueMatcher = (anyValue ? anything() : asMatcher(valueOrMatcher));
-	return _.create(new IsPromise(), {
+	return _create(new IsPromise(), {
 		matchesSafely: function (actual) {
 			return actual.then((value) => {
 				return valueMatcher.matches(value);

--- a/lib/matchers/IsFunction.js
+++ b/lib/matchers/IsFunction.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isFunction = require('lodash/isFunction');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsFunction() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isFunction(actual);
+			return _isFunction(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsFunctionThrowing.js
+++ b/lib/matchers/IsFunctionThrowing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsFunction = require('./IsFunction');
 const asMatcher = require('../utils/asMatcher');
 const anything = require('./IsAnything').anything;
@@ -8,7 +8,7 @@ const anything = require('./IsAnything').anything;
 function IsFunctionThrowing(valueOrMatcher) {
 	const anyValue = (arguments.length === 0);
 	const exceptionMatcher = (anyValue ? anything() : asMatcher(valueOrMatcher));
-	return _.create(new IsFunction(), {
+	return _create(new IsFunction(), {
 		matchesSafely: function (throwingFunction) {
 			try {
 				throwingFunction();

--- a/lib/matchers/IsInstanceOf.js
+++ b/lib/matchers/IsInstanceOf.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isUndefined = require('lodash/isUndefined');
 const Matcher = require('./Matcher');
 const assertThat = require('../assertThat');
 const is = require('./Is').is;
@@ -11,7 +12,7 @@ const getTypeName = require('../utils/getTypeName');
 function IsInstanceOf(expectedType) {
 	assertThat(expectedType, is(func()));
 
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actual) {
 			return actual instanceof expectedType;
 		},
@@ -21,7 +22,7 @@ function IsInstanceOf(expectedType) {
 				.append(getTypeName(expectedType));
 		},
 		describeMismatch: function (actual, description) {
-			if (_.isUndefined(actual)) {
+			if (_isUndefined(actual)) {
 				description
 					.append('was ')
 					.appendValue(actual);

--- a/lib/matchers/IsNot.js
+++ b/lib/matchers/IsNot.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 const promiseAgnostic = require('./promiseAgnostic');
 const asMatcher = require('../utils/asMatcher');
 
 function IsNot(valueOrMatcher) {
 	const innerMatcher = asMatcher(valueOrMatcher);
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actual) {
 			return promiseAgnostic.matches(innerMatcher.matches(actual), (result) => {
 				return !result;

--- a/lib/matchers/IsNot.js
+++ b/lib/matchers/IsNot.js
@@ -2,10 +2,11 @@
 
 const _ = require('lodash');
 const Matcher = require('./Matcher');
-const acceptingMatcher = require('../utils/acceptingMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
+const asMatcher = require('../utils/asMatcher');
 
-const IsNot = acceptingMatcher((innerMatcher) => {
+function IsNot(valueOrMatcher) {
+	const innerMatcher = asMatcher(valueOrMatcher);
 	return _.create(new Matcher(), {
 		matches: function (actual) {
 			return promiseAgnostic.matches(innerMatcher.matches(actual), (result) => {
@@ -23,7 +24,7 @@ const IsNot = acceptingMatcher((innerMatcher) => {
 				.appendValue(value);
 		}
 	});
-});
+}
 
 IsNot.not = function (innerMatcher) {
 	return new IsNot(innerMatcher);

--- a/lib/matchers/IsNumber.js
+++ b/lib/matchers/IsNumber.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isNumber = require('lodash/isNumber');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsNumber() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isNumber(actual);
+			return _isNumber(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsObject.js
+++ b/lib/matchers/IsObject.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isObject = require('lodash/isObject');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsObject() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isObject(actual);
+			return _isObject(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsObjectWithProperties.js
+++ b/lib/matchers/IsObjectWithProperties.js
@@ -1,6 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _every = require('lodash/every');
+const _forEach = require('lodash/forEach');
+const _isArray = require('lodash/isArray');
+const _isUndefined = require('lodash/isUndefined');
+const _map = require('lodash/map');
+const _mapValues = require('lodash/mapValues');
+const _reduceRight = require('lodash/reduceRight');
 const contains = require('./IsArrayContaining').contains;
 const IsObject = require('./IsObject');
 const isMatcher = require('./Matcher').isMatcher;
@@ -13,28 +20,28 @@ function asDeepMatcher(value) {
 		if (value.constructor === Object || Object.getPrototypeOf(value) === null) {
 			return new IsObjectWithProperties(value, true);
 		}
-		if (_.isArray(value)) {
-			return contains(..._.map(value, v => asDeepMatcher(v)));
+		if (_isArray(value)) {
+			return contains(..._map(value, v => asDeepMatcher(v)));
 		}
 	}
 	return asMatcher(value);
 }
 
 function IsObjectWithProperties(properties, deep = false) {
-	const propertyMatchers = _.mapValues(properties, deep ? asDeepMatcher : asMatcher);
-	return _.create(new IsObject(), {
+	const propertyMatchers = _mapValues(properties, deep ? asDeepMatcher : asMatcher);
+	return _create(new IsObject(), {
 		matchesSafely: function (actual) {
-			const results = _.mapValues(propertyMatchers, (matcher, key) => {
+			const results = _mapValues(propertyMatchers, (matcher, key) => {
 				return matcher.matches(actual[key]);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, _.every);
+			return promiseAgnostic.matchesAggregate(results, _every);
 		},
 		describeTo: function (description) {
 			description.append('an object with {');
 
 			let first = true;
-			_.forEach(propertyMatchers, (matcher, key) => {
+			_forEach(propertyMatchers, (matcher, key) => {
 				if (!first) {
 					description.append(', ');
 				}
@@ -49,7 +56,7 @@ function IsObjectWithProperties(properties, deep = false) {
 			description.append('}');
 		},
 		describeMismatchSafely: function (actual, description) {
-			const results = _.mapValues(propertyMatchers, (matcher, key) => {
+			const results = _mapValues(propertyMatchers, (matcher, key) => {
 				return matcher.matches(actual[key]);
 			});
 
@@ -91,10 +98,10 @@ IsObjectWithProperties.hasDeepProperties = function (properties) {
 };
 
 IsObjectWithProperties.hasProperty = function (propertyOrPath, valueOrMatcher) {
-	const propertyPath = _.isArray(propertyOrPath) ? propertyOrPath : propertyOrPath.split('.');
+	const propertyPath = _isArray(propertyOrPath) ? propertyOrPath : propertyOrPath.split('.');
 	const propertyToNestedMatcher = (matcher, prop) => new IsObjectWithProperties({[prop]: matcher});
-	const initialMatcher = _.isUndefined(valueOrMatcher) ? defined() : valueOrMatcher;
-	return _.reduceRight(propertyPath, propertyToNestedMatcher, initialMatcher);
+	const initialMatcher = _isUndefined(valueOrMatcher) ? defined() : valueOrMatcher;
+	return _reduceRight(propertyPath, propertyToNestedMatcher, initialMatcher);
 };
 
 module.exports = IsObjectWithProperties;

--- a/lib/matchers/IsPromise.js
+++ b/lib/matchers/IsPromise.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isFunction = require('lodash/isFunction');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsPromise() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return actual && _.isFunction(actual.then);
+			return actual && _isFunction(actual.then);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsRegExp.js
+++ b/lib/matchers/IsRegExp.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const _ = require('lodash');
+const _isRegExp = require('lodash/isRegExp');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 class IsRegExp extends TypeSafeMatcher {
 	isExpectedType(actual) {
-		return _.isRegExp(actual);
+		return _isRegExp(actual);
 	}
 	describeTo(description) {
 		description

--- a/lib/matchers/IsRegExp.js
+++ b/lib/matchers/IsRegExp.js
@@ -11,10 +11,9 @@ class IsRegExp extends TypeSafeMatcher {
 		description
 			.append('a regular expression');
 	}
+	static regExp() {
+		return new IsRegExp();
+	}
 }
-
-IsRegExp.regExp = function () {
-	return new IsRegExp();
-};
 
 module.exports = IsRegExp;

--- a/lib/matchers/IsRejected.js
+++ b/lib/matchers/IsRejected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsPromise = require('./IsPromise');
 const asMatcher = require('../utils/asMatcher');
 const anything = require('./IsAnything').anything;
@@ -8,7 +8,7 @@ const anything = require('./IsAnything').anything;
 function IsRejected(valueOrMatcher) {
 	const anyValue = (arguments.length === 0);
 	const valueMatcher = (anyValue ? anything() : asMatcher(valueOrMatcher));
-	return _.create(new IsPromise(), {
+	return _create(new IsPromise(), {
 		matchesSafely: function (actual) {
 			return actual.then(() => false, (reason) => {
 				return valueMatcher.matches(reason);

--- a/lib/matchers/IsSame.js
+++ b/lib/matchers/IsSame.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 
 function IsSame(expectedValue) {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actualValue) {
 			return expectedValue === actualValue;
 		},

--- a/lib/matchers/IsString.js
+++ b/lib/matchers/IsString.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isString = require('lodash/isString');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 
 function IsString() {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isString(actual);
+			return _isString(actual);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/IsStringMatching.js
+++ b/lib/matchers/IsStringMatching.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsString = require('./IsString');
 const assertThat = require('../assertThat');
 const anyOf = require('./AnyOf').anyOf;
@@ -12,7 +12,7 @@ function IsStringMatching(stringOrPattern) {
 
 	const pattern = new RegExp(stringOrPattern);
 
-	return _.create(new IsString(), {
+	return _create(new IsString(), {
 		matchesSafely: function (actual) {
 			return pattern.test(actual);
 		},

--- a/lib/matchers/Matcher.js
+++ b/lib/matchers/Matcher.js
@@ -1,10 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
+const _extend = require('lodash/extend');
+const _isFunction = require('lodash/isFunction');
+const _isNull = require('lodash/isNull');
+const _isUndefined = require('lodash/isUndefined');
 
 class Matcher {
 	constructor(fns = {}) {
-		_.extend(this, fns);
+		_extend(this, fns);
 	}
 	matches() {
 		throw new Error('Not implemented');
@@ -16,11 +19,11 @@ class Matcher {
 		description.append('was ').appendValue(value);
 	}
 	static isMatcher(valueOrMatcher) {
-		return !_.isUndefined(valueOrMatcher) &&
-			!_.isNull(valueOrMatcher) &&
-			_.isFunction(valueOrMatcher.matches) &&
-			_.isFunction(valueOrMatcher.describeTo) &&
-			_.isFunction(valueOrMatcher.describeMismatch);
+		return !_isUndefined(valueOrMatcher) &&
+			!_isNull(valueOrMatcher) &&
+			_isFunction(valueOrMatcher.matches) &&
+			_isFunction(valueOrMatcher.describeTo) &&
+			_isFunction(valueOrMatcher.describeMismatch);
 	}
 }
 

--- a/lib/matchers/NumberComparisonMatcher.js
+++ b/lib/matchers/NumberComparisonMatcher.js
@@ -28,19 +28,20 @@ function NumberComparisonMatcher(relation, threshold, matchesNumber) {
 	});
 }
 
-_.extend(NumberComparisonMatcher, {
-	greaterThan: function (threshold) {
-		return new NumberComparisonMatcher('greater than', threshold, (actual) => actual > threshold);
-	},
-	greaterThanOrEqualTo: function (threshold) {
-		return new NumberComparisonMatcher('greater than or equal to', threshold, (actual) => actual >= threshold);
-	},
-	lessThan: function (threshold) {
-		return new NumberComparisonMatcher('less than', threshold, (actual) => actual < threshold);
-	},
-	lessThanOrEqualTo: function (threshold) {
-		return new NumberComparisonMatcher('less than or equal to', threshold, (actual) => actual <= threshold);
-	}
-});
+NumberComparisonMatcher.greaterThan = function (threshold) {
+	return new NumberComparisonMatcher('greater than', threshold, (actual) => actual > threshold);
+};
+
+NumberComparisonMatcher.greaterThanOrEqualTo = function (threshold) {
+	return new NumberComparisonMatcher('greater than or equal to', threshold, (actual) => actual >= threshold);
+};
+
+NumberComparisonMatcher.lessThan = function (threshold) {
+	return new NumberComparisonMatcher('less than', threshold, (actual) => actual < threshold);
+};
+
+NumberComparisonMatcher.lessThanOrEqualTo = function (threshold) {
+	return new NumberComparisonMatcher('less than or equal to', threshold, (actual) => actual <= threshold);
+};
 
 module.exports = NumberComparisonMatcher;

--- a/lib/matchers/NumberComparisonMatcher.js
+++ b/lib/matchers/NumberComparisonMatcher.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const IsNumber = require('./IsNumber');
 const assertThat = require('../assertThat');
 const is = require('./Is').is;
@@ -9,7 +9,7 @@ const number = require('./IsNumber').number;
 function NumberComparisonMatcher(relation, threshold, matchesNumber) {
 	assertThat(threshold, is(number()));
 
-	return _.create(new IsNumber(), {
+	return _create(new IsNumber(), {
 		matchesSafely: function (actual) {
 			return matchesNumber.call(this, actual);
 		},

--- a/lib/matchers/SubstringMatcher.js
+++ b/lib/matchers/SubstringMatcher.js
@@ -30,42 +30,43 @@ function SubstringMatcher(substring, relation, matchesString) {
 	});
 }
 
-_.extend(SubstringMatcher, {
-	containsString(substring) {
-		return new SubstringMatcher(substring, 'containing', (actualString) => {
-			return actualString.indexOf(substring) !== -1;
-		});
-	},
-	containsStrings(...substrings) {
-		substrings.map((s) => assertThat(s, is(string())));
-		return _.create(new IsString(), {
-			matchesSafely(actual) {
-				return _.every(substrings, (s) => actual.indexOf(s) !== -1);
-			},
-			describeTo(description) {
-				description
-					.append('a string containing ')
-					.appendList('', ', ', '', substrings);
-			},
-			describeMismatchSafely(actual, description) {
-				const notFound = _.filter(substrings, (s) => actual.indexOf(s) === -1);
-				description
-					.appendList('', ', ', '', notFound)
-					.append(' could not be found in ')
-					.appendValue(actual);
-			},
-		});
-	},
-	startsWith(prefix) {
-		return new SubstringMatcher(prefix, 'starting with', (actualString) => {
-			return actualString.indexOf(prefix) === 0;
-		});
-	},
-	endsWith(suffix) {
-		return new SubstringMatcher(suffix, 'ending with', (actualString) => {
-			return actualString.indexOf(suffix, actualString.length - suffix.length) !== -1;
-		});
-	}
-});
+SubstringMatcher.containsString = function (substring) {
+	return new SubstringMatcher(substring, 'containing', (actualString) => {
+		return actualString.indexOf(substring) !== -1;
+	});
+};
+
+SubstringMatcher.containsStrings = function (...substrings) {
+	substrings.map((s) => assertThat(s, is(string())));
+	return _.create(new IsString(), {
+		matchesSafely(actual) {
+			return _.every(substrings, (s) => actual.indexOf(s) !== -1);
+		},
+		describeTo(description) {
+			description
+				.append('a string containing ')
+				.appendList('', ', ', '', substrings);
+		},
+		describeMismatchSafely(actual, description) {
+			const notFound = _.filter(substrings, (s) => actual.indexOf(s) === -1);
+			description
+				.appendList('', ', ', '', notFound)
+				.append(' could not be found in ')
+				.appendValue(actual);
+		},
+	});
+};
+
+SubstringMatcher.startsWith = function (prefix) {
+	return new SubstringMatcher(prefix, 'starting with', (actualString) => {
+		return actualString.indexOf(prefix) === 0;
+	});
+};
+
+SubstringMatcher.endsWith = function (suffix) {
+	return new SubstringMatcher(suffix, 'ending with', (actualString) => {
+		return actualString.indexOf(suffix, actualString.length - suffix.length) !== -1;
+	});
+};
 
 module.exports = SubstringMatcher;

--- a/lib/matchers/SubstringMatcher.js
+++ b/lib/matchers/SubstringMatcher.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _every = require('lodash/every');
+const _filter = require('lodash/filter');
 const IsString = require('./IsString');
 const assertThat = require('../assertThat');
 const is = require('./Is').is;
@@ -9,7 +11,7 @@ const string = require('./IsString').string;
 function SubstringMatcher(substring, relation, matchesString) {
 	assertThat(substring, is(string()));
 
-	return _.create(new IsString(), {
+	return _create(new IsString(), {
 		matchesSafely(actual) {
 			return matchesString.call(this, actual);
 		},
@@ -38,9 +40,9 @@ SubstringMatcher.containsString = function (substring) {
 
 SubstringMatcher.containsStrings = function (...substrings) {
 	substrings.map((s) => assertThat(s, is(string())));
-	return _.create(new IsString(), {
+	return _create(new IsString(), {
 		matchesSafely(actual) {
-			return _.every(substrings, (s) => actual.indexOf(s) !== -1);
+			return _every(substrings, (s) => actual.indexOf(s) !== -1);
 		},
 		describeTo(description) {
 			description
@@ -48,7 +50,7 @@ SubstringMatcher.containsStrings = function (...substrings) {
 				.appendList('', ', ', '', substrings);
 		},
 		describeMismatchSafely(actual, description) {
-			const notFound = _.filter(substrings, (s) => actual.indexOf(s) === -1);
+			const notFound = _filter(substrings, (s) => actual.indexOf(s) === -1);
 			description
 				.appendList('', ', ', '', notFound)
 				.append(' could not be found in ')

--- a/lib/matchers/failsToMatch.js
+++ b/lib/matchers/failsToMatch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Description = require('./../Description');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 const anything = require('./IsAnything').anything;
@@ -9,7 +9,7 @@ const isMatcher = require('./Matcher').isMatcher;
 
 function failsToMatch(target, descriptionMatcher) {
 	descriptionMatcher = descriptionMatcher ? asMatcher(descriptionMatcher) : anything();
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
 			return isMatcher(actual);
 		},

--- a/lib/matchers/falsy.js
+++ b/lib/matchers/falsy.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 
 function falsy() {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actualValue) {
 			return !actualValue;
 		},

--- a/lib/matchers/hasDescription.js
+++ b/lib/matchers/hasDescription.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Description = require('./../Description');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 const asMatcher = require('../utils/asMatcher');
@@ -8,7 +8,7 @@ const isMatcher = require('./Matcher').isMatcher;
 
 module.exports = function (valueOrMatcher) {
 	const descriptionMatcher = asMatcher(valueOrMatcher);
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
 			return isMatcher(actual);
 		},

--- a/lib/matchers/hasDescription.js
+++ b/lib/matchers/hasDescription.js
@@ -3,10 +3,11 @@
 const _ = require('lodash');
 const Description = require('./../Description');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
-const acceptingMatcher = require('../utils/acceptingMatcher');
+const asMatcher = require('../utils/asMatcher');
 const isMatcher = require('./Matcher').isMatcher;
 
-module.exports = acceptingMatcher((descriptionMatcher) => {
+module.exports = function (valueOrMatcher) {
+	const descriptionMatcher = asMatcher(valueOrMatcher);
 	return _.create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
 			return isMatcher(actual);
@@ -29,4 +30,4 @@ module.exports = acceptingMatcher((descriptionMatcher) => {
 			descriptionMatcher.describeMismatch(actualDescription, description);
 		}
 	});
-});
+};

--- a/lib/matchers/hasExactlyOneItem.js
+++ b/lib/matchers/hasExactlyOneItem.js
@@ -2,10 +2,11 @@
 
 const _ = require('lodash');
 const IsArray = require('./IsArray');
-const acceptingMatcher = require('../utils/acceptingMatcher');
 const promiseAgnostic = require('./promiseAgnostic');
+const asMatcher = require('../utils/asMatcher');
 
-module.exports = acceptingMatcher((matcher) => {
+module.exports = function (valueOrMatcher) {
+	const matcher = asMatcher(valueOrMatcher);
 	return _.create(new IsArray(), {
 		matchesSafely: function (actual) {
 			const results = _.map(actual, (value) => {
@@ -67,4 +68,4 @@ module.exports = acceptingMatcher((matcher) => {
 			}));
 		}
 	});
-});
+};

--- a/lib/matchers/hasExactlyOneItem.js
+++ b/lib/matchers/hasExactlyOneItem.js
@@ -1,19 +1,21 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _filter = require('lodash/filter');
+const _map = require('lodash/map');
 const IsArray = require('./IsArray');
 const promiseAgnostic = require('./promiseAgnostic');
 const asMatcher = require('../utils/asMatcher');
 
 module.exports = function (valueOrMatcher) {
 	const matcher = asMatcher(valueOrMatcher);
-	return _.create(new IsArray(), {
+	return _create(new IsArray(), {
 		matchesSafely: function (actual) {
-			const results = _.map(actual, (value) => {
+			const results = _map(actual, (value) => {
 				return matcher.matches(value);
 			});
 
-			return promiseAgnostic.matchesAggregate(results, (results) => _.filter(results).length === 1);
+			return promiseAgnostic.matchesAggregate(results, (results) => _filter(results).length === 1);
 		},
 		describeTo: function (description) {
 			description
@@ -25,7 +27,7 @@ module.exports = function (valueOrMatcher) {
 				description.append('was empty');
 				return;
 			}
-			const results = _.map(actual, (value) => {
+			const results = _map(actual, (value) => {
 				return matcher.matches(value);
 			});
 

--- a/lib/matchers/hasSize.js
+++ b/lib/matchers/hasSize.js
@@ -1,14 +1,17 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _isObject = require('lodash/isObject');
+const _isString = require('lodash/isString');
+const _size = require('lodash/size');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 const FeatureMatcher = require('./FeatureMatcher');
 
 module.exports = function (valueOrMatcher) {
-	const innerMatcher = new FeatureMatcher(valueOrMatcher, 'a collection or string with size', 'size', (item) => _.size(item));
-	return _.create(new TypeSafeMatcher(), {
+	const innerMatcher = new FeatureMatcher(valueOrMatcher, 'a collection or string with size', 'size', (item) => _size(item));
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
-			return _.isString(actual) || _.isObject(actual);
+			return _isString(actual) || _isObject(actual);
 		},
 		matchesSafely: innerMatcher.matches,
 		describeTo: innerMatcher.describeTo,

--- a/lib/matchers/inRange.js
+++ b/lib/matchers/inRange.js
@@ -1,12 +1,14 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
+const _inRange = require('lodash/inRange');
+const _isUndefined = require('lodash/isUndefined');
 const assertThat = require('../assertThat');
 const is = require('../matchers/Is').is;
 const isNumber = require('../matchers/IsNumber').number;
 
 module.exports = function (start, end) {
-	if (_.isUndefined(end)) {
+	if (_isUndefined(end)) {
 		end = start;
 		start = 0;
 	}
@@ -14,9 +16,9 @@ module.exports = function (start, end) {
 	assertThat('Start', start, is(isNumber()));
 	assertThat('End', end, is(isNumber()));
 
-	return _.create(isNumber(), {
+	return _create(isNumber(), {
 		matchesSafely: function (actual) {
-			return _.inRange(actual, start, end);
+			return _inRange(actual, start, end);
 		},
 		describeTo: function (description) {
 			description

--- a/lib/matchers/inRange.js
+++ b/lib/matchers/inRange.js
@@ -1,19 +1,20 @@
 'use strict';
 
 const _ = require('lodash');
+const assertThat = require('../assertThat');
+const is = require('../matchers/Is').is;
+const isNumber = require('../matchers/IsNumber').number;
 
 module.exports = function (start, end) {
-	const __ = require('../..');
-
 	if (_.isUndefined(end)) {
 		end = start;
 		start = 0;
 	}
 
-	__.assertThat('Start', start, __.is(__.number()));
-	__.assertThat('End', end, __.is(__.number()));
+	assertThat('Start', start, is(isNumber()));
+	assertThat('End', end, is(isNumber()));
 
-	return _.create(__.number(), {
+	return _.create(isNumber(), {
 		matchesSafely: function (actual) {
 			return _.inRange(actual, start, end);
 		},

--- a/lib/matchers/isEmpty.js
+++ b/lib/matchers/isEmpty.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const _ = require('lodash');
+const _extend = require('lodash/extend');
 const hasSize = require('./hasSize');
 
 module.exports = function () {
-	return _.extend(hasSize(0), {
+	return _extend(hasSize(0), {
 		describeTo: function (description) {
 			description.append('an empty collection or string');
 		}

--- a/lib/matchers/matches.js
+++ b/lib/matchers/matches.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Description = require('./../Description');
 const TypeSafeMatcher = require('./TypeSafeMatcher');
 const isMatcher = require('./Matcher').isMatcher;
 
 function matches(target) {
-	return _.create(new TypeSafeMatcher(), {
+	return _create(new TypeSafeMatcher(), {
 		isExpectedType: function (actual) {
 			return isMatcher(actual);
 		},

--- a/lib/matchers/promiseAgnostic.js
+++ b/lib/matchers/promiseAgnostic.js
@@ -1,10 +1,15 @@
 'use strict';
 
-const _ = require('lodash');
+const _forEach = require('lodash/forEach');
+const _identity = require('lodash/identity');
+const _isArray = require('lodash/isArray');
+const _isFunction = require('lodash/isFunction');
+const _reduce = require('lodash/reduce');
+const _some = require('lodash/some');
 const Bluebird = require('bluebird');
 
 function resolve(promises) {
-	if (_.isArray(promises)) {
+	if (_isArray(promises)) {
 		return Bluebird.all(promises);
 	} else {
 		return Bluebird.props(promises);
@@ -20,22 +25,22 @@ const promiseAgnostic = {
 		}
 	},
 	matchesAggregate: function (results, handler) {
-		if (_.some(results, isPromise)) {
+		if (_some(results, isPromise)) {
 			return resolve(results).then(handler);
 		} else {
 			return handler(results);
 		}
 	},
 	describeMismatchAggregate: function (results, handler, suffixFn) {
-		if (_.some(results, isPromise)) {
+		if (_some(results, isPromise)) {
 			return resolve(results).then((results) => {
-				return _.reduce(results, (chain, result, key) => {
+				return _reduce(results, (chain, result, key) => {
 					return chain.then(() => handler(result, key));
 				}, Bluebird.resolve());
 			})
-			.then(suffixFn || _.identity);
+			.then(suffixFn || _identity);
 		} else {
-			_.forEach(results, (result, key) => {
+			_forEach(results, (result, key) => {
 				return handler(result, key);
 			});
 			if (suffixFn) {
@@ -47,7 +52,7 @@ const promiseAgnostic = {
 		if (isPromise(result)) {
 			return Bluebird.resolve(result)
 			.then(handler)
-			.then(suffixFn || _.identity);
+			.then(suffixFn || _identity);
 		} else {
 			handler(result);
 			if (suffixFn) {
@@ -58,7 +63,7 @@ const promiseAgnostic = {
 };
 
 function isPromise(value) {
-	return value && _.isFunction(value.then);
+	return value && _isFunction(value.then);
 }
 
 module.exports = promiseAgnostic;

--- a/lib/matchers/returns.js
+++ b/lib/matchers/returns.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const anything = require('./IsAnything').anything;
 const asMatcher = require('../utils/asMatcher');
 const func = require('./IsFunction').func;
@@ -8,7 +8,7 @@ const getType = require('../utils/getType');
 
 module.exports = function returns(resultValueOrMatcher) {
 	const resultMatcher = resultValueOrMatcher ? asMatcher(resultValueOrMatcher) : anything();
-	return _.create(func(), {
+	return _create(func(), {
 		matchesSafely: function (actual) {
 			try {
 				const result = actual();

--- a/lib/matchers/truthy.js
+++ b/lib/matchers/truthy.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const _ = require('lodash');
+const _create = require('lodash/create');
 const Matcher = require('./Matcher');
 
 function truthy() {
-	return _.create(new Matcher(), {
+	return _create(new Matcher(), {
 		matches: function (actualValue) {
 			return !!actualValue;
 		},

--- a/lib/promiseThat.js
+++ b/lib/promiseThat.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _isFunction = require('lodash/isFunction');
 const AssertionError = require('assertion-error');
 const Bluebird = require('bluebird');
 
@@ -22,8 +22,8 @@ function promiseThat(reason, actual, matcher) {
 				.append('\n     but: ');
 			return Bluebird.try(() => matcher.describeMismatch(actual, description))
 			.then(() => {
-				if (!_.isFunction(matcher.getExpectedForDiff) ||
-					!_.isFunction(matcher.formatActualForDiff)) {
+				if (!_isFunction(matcher.getExpectedForDiff) ||
+					!_isFunction(matcher.formatActualForDiff)) {
 					return {};
 				}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hamjest",
   "version": "3.7.3",
-  "main": "index.js",
+  "main": "lib/hamjest.js",
   "description": "A library of composable matchers for defining meaningful and readable assertions in JavaScript.",
   "homepage": "https://github.com/rluba/hamjest",
   "author": {

--- a/test/node/esm/.eslintrc
+++ b/test/node/esm/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"parserOptions": {
+		"sourceType": "module"
+	}
+}


### PR DESCRIPTION
When used with bundlers (rollup, webpack), unused `matchers` are not removed from the final package, in addition, if special plugins are not used that replace the `lodash` import with a specific method import it becomes entirely bundled too.

> Packet size is important to me because I want to use `hamjest` in [k6](https://k6.io/) where the size can make a big difference in the final result.

What I changed:
- Used `asMatcher` in matchers created using `acceptingMatcher` previously.
- Replaced imports of full `lodash` with `lodash/<method>`.
- Exported `lib/hamjest.js` directly (rollup doesn't optimize re-exports).

Results:
- Webpack: `180 KB` -> `141 KB` (without `bluebird` 62 KB).
- Rollup: `186 KB` -> `112 KB` (without `bluebird` 24 KB).

```javascript
import { assertThat, truthy } from 'hamjest';

assertThat(true, truthy())
```

🚨 I would like to replace `bluebird` with the native promises that are supported since `Node.js 0.12.0`, but this would introduce a breaking change due to a change in return type that lacks bluebird-specific methods. If you agree with this change let me know and I'll be happy to add it to this or a separate PR.
