### PR TITLE
fix: invalid chai property error when chai is added globally

### DIFF
--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -41,7 +41,7 @@ const assertThat = (...args) => {
 	} else {
 		if (global && global.expect) {
 			const expectation = global.expect();
-			if (expectation && expectation.nothing) {
+			if (expectation && 'nothing' in expectation) {
 				expectation.nothing();
 			}
 		}

--- a/test/node/assertThatSpec.js
+++ b/test/node/assertThatSpec.js
@@ -114,4 +114,18 @@ describe('assertThat', () => {
 
 		assert.equal(expectNothingWasCalled, true);
 	});
+
+	it('should not throw when nothing is not available on expect (fix "Invalid Chai property" in vitest)', () => {
+		const chaiFake = {irrelevant: 'property'};
+
+		global.expect = () => new Proxy(chaiFake, {
+			get(target, property) {
+				if (!Object.keys(target).includes(property)) {
+					throw Error(`Invalid Chai property: ${property}`);
+				}
+			}
+		});
+
+		__.assertThat(true, __.is(__.equalTo(true)));
+	});
 });


### PR DESCRIPTION
[Vitest](https://vitest.dev/) uses [chai](https://www.chaijs.com/) under the hood. When setting globals to true it automatically adds chai to the global scope when running tests. https://github.com/rluba/hamjest/pull/30 adds a fix for [Jasmine](https://jasmine.github.io/) to not add a warning or throw an error in case a test does not have an assertion from Jasmin itself. The fix for Jasmin throws the following error in Vitest (where chai is installed globally): `Error: Invalid Chai property: nothing. Did you mean "within"?`. This is due to the following [proxy implementation](https://github.com/chaijs/chai/blob/936c0ca9a4b60193364b9e6e4338bb69f2f28a98/lib/chai/utils/proxify.js#L75C23-L75C47) which verifies if a property which is accessed from the expectation is actually available. Changing the implementation from a property access undefined check to the [in operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) fixes this issue. 

Switching off globals in vitests config fixes the issue for me, but I have a feeling somebody else in the future might encounter the same issue. 


